### PR TITLE
[BUG][MH] Project month filtering not working. Solution: date in data…

### DIFF
--- a/client/src/components/shared/ProjectListingCard.jsx
+++ b/client/src/components/shared/ProjectListingCard.jsx
@@ -100,14 +100,14 @@ const _ProjectListingCard = ({ project, classes }) => {
                         {project.projectType === 'RECURRING'
                           ? 'Recurring Project'
                           : project.startDate === project.endDate
-                            ? moment(project.startDate).format(
+                            ? moment(project.startDate).utc().format(
                               'dddd, Do MMMM YYYY'
                             )
-                            : moment(project.startDate).format(
+                            : moment(project.startDate).utc().format(
                               'dddd, Do MMMM YYYY'
                             ) +
                             ' - ' +
-                            moment(project.endDate).format(
+                            moment(project.endDate).utc().format(
                               'dddd, Do MMMM YYYY'
                             )}
                       </Typography>
@@ -141,11 +141,11 @@ const _ProjectListingCard = ({ project, classes }) => {
                       ) : (
                         <Paper elevation={0} className={classes.dateBadge}>
                           <Typography variant="caption">
-                            {moment(project.startDate).format('MMM')}
+                            {moment(project.startDate).utc().format('MMM')}
                           </Typography>
                           <Typography variant="title" color="secondary">
                             <strong>
-                              {moment(project.startDate).format('DD')}
+                              {moment(project.startDate).utc().format('DD')}
                             </strong>
                           </Typography>
                         </Paper>

--- a/client/src/components/shared/ProjectMainInfo.jsx
+++ b/client/src/components/shared/ProjectMainInfo.jsx
@@ -232,12 +232,14 @@ const renderProjectDetails = (classes, project) => {
         renderRow(
           'Start date',
           moment(startDate)
+            .utc()
             .format('dddd, Do MMMM YYYY')
         )}
       {projectType === ProjectType.EVENT &&
         renderRow(
           'End date',
           moment(endDate)
+            .utc()
             .format('dddd, Do MMMM YYYY')
         )}
       {projectType === ProjectType.RECURRING &&


### PR DESCRIPTION
…base is stored as UTC. In ProjectListingCard and ProjectMainInfo the moment(startDate|endDate) must be specified as .utc() before .format() so that it's not adjusted to local date.